### PR TITLE
Enabled caching with content checksums

### DIFF
--- a/src/Process/MJML.php
+++ b/src/Process/MJML.php
@@ -3,9 +3,9 @@
 namespace Asahasrabuddhe\LaravelMJML\Process;
 
 use Html2Text\Html2Text;
+use Illuminate\View\View;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Facades\File;
-use Illuminate\View\View;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 
@@ -38,7 +38,7 @@ class MJML
     }
 
     /**
-     * Build the mjml command
+     * Build the mjml command.
      *
      * @return string
      */
@@ -53,7 +53,7 @@ class MJML
     }
 
     /**
-     * Render the html content
+     * Render the html content.
      *
      * @return HtmlString
      *
@@ -65,15 +65,15 @@ class MJML
 
         File::put($this->path, $html);
 
-        $contentChecksum = hash('sha256', $html);
+        $contentChecksum    = hash('sha256', $html);
         $this->compiledPath = storage_path("framework/views/{$contentChecksum}.php");
 
-        if (!File::exists($this->compiledPath)) {
+        if (! File::exists($this->compiledPath)) {
 
             $this->process = new Process($this->buildCmdLineFromConfig());
             $this->process->run();
 
-            if (!$this->process->isSuccessful()) {
+            if (! $this->process->isSuccessful()) {
                 throw new ProcessFailedException($this->process);
             }
         }
@@ -81,7 +81,7 @@ class MJML
     }
 
     /**
-     * Render the text content
+     * Render the text content.
      *
      * @return HtmlString
      *
@@ -94,7 +94,7 @@ class MJML
     }
 
     /**
-     * Detect the path to the mjml executable
+     * Detect the path to the mjml executable.
      *
      * @return string
      */

--- a/src/Process/MJML.php
+++ b/src/Process/MJML.php
@@ -69,7 +69,6 @@ class MJML
         $this->compiledPath = storage_path("framework/views/{$contentChecksum}.php");
 
         if (! File::exists($this->compiledPath)) {
-
             $this->process = new Process($this->buildCmdLineFromConfig());
             $this->process->run();
 
@@ -77,6 +76,7 @@ class MJML
                 throw new ProcessFailedException($this->process);
             }
         }
+
         return new HtmlString(File::get($this->compiledPath));
     }
 

--- a/src/Process/MJML.php
+++ b/src/Process/MJML.php
@@ -5,26 +5,43 @@ namespace Asahasrabuddhe\LaravelMJML\Process;
 use Html2Text\Html2Text;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Facades\File;
+use Illuminate\View\View;
 use Symfony\Component\Process\Process;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 
 class MJML
 {
+    /**
+     * @var Process
+     */
     protected $process;
 
+    /**
+     * @var View
+     */
     protected $view;
 
+    /**
+     * @var string
+     */
     protected $path;
 
-    protected $options;
-
+    /**
+     * MJML constructor.
+     *
+     * @param View $view
+     */
     public function __construct($view)
     {
-        $this->view         = $view;
-        $this->path         = storage_path('framework/views/' . sha1($this->view->getPath()) . '.php');
-        $this->compiledPath = storage_path('framework/views/' . sha1($this->view->getPath() . '_compiled') . '.php');
+        $this->view = $view;
+        $this->path = storage_path('framework/views/' . sha1($this->view->getPath()) . '.php');
     }
 
+    /**
+     * Build the mjml command
+     *
+     * @return string
+     */
     public function buildCmdLineFromConfig()
     {
         return implode(' ', [
@@ -35,27 +52,52 @@ class MJML
         ]);
     }
 
+    /**
+     * Render the html content
+     *
+     * @return HtmlString
+     *
+     * @throws \Throwable
+     */
     public function renderHTML()
     {
         $html = $this->view->render();
+
         File::put($this->path, $html);
 
-        $this->process = new Process($this->buildCmdLineFromConfig());
-        $this->process->run();
-        // executes after the command finishes
-        File::delete($this->path);
-        if (! $this->process->isSuccessful()) {
-            throw new ProcessFailedException($this->process);
-        }
+        $contentChecksum = hash('sha256', $html);
+        $this->compiledPath = storage_path("framework/views/{$contentChecksum}.php");
 
+        if (!File::exists($this->compiledPath)) {
+
+            $this->process = new Process($this->buildCmdLineFromConfig());
+            $this->process->run();
+
+            if (!$this->process->isSuccessful()) {
+                throw new ProcessFailedException($this->process);
+            }
+        }
         return new HtmlString(File::get($this->compiledPath));
     }
 
+    /**
+     * Render the text content
+     *
+     * @return HtmlString
+     *
+     * @throws \Html2Text\Html2TextException
+     * @throws \Throwable
+     */
     public function renderText()
     {
         return new HtmlString(html_entity_decode(preg_replace("/[\r\n]{2,}/", "\n\n", Html2Text::convert($this->renderHTML())), ENT_QUOTES, 'UTF-8'));
     }
 
+    /**
+     * Detect the path to the mjml executable
+     *
+     * @return string
+     */
     public function detectBinaryPath()
     {
         return base_path('node_modules/.bin/mjml');


### PR DESCRIPTION
- Completed the code documentation.
- Updated the rendering process to cache by the mjml content checksum.

This does not affect the behaviour mentioned in #9 since the content is validated by a sha256 checksum.