### PR TITLE
use data as a cache key

### DIFF
--- a/src/Process/MJML.php
+++ b/src/Process/MJML.php
@@ -34,7 +34,7 @@ class MJML
     public function __construct($view)
     {
         $this->view = $view;
-        $this->path = storage_path('framework/views/' . sha1($this->view->getPath()) . '.php');
+        $this->path = storage_path('framework/views/' . sha1($this->view->getPath()).sha1(serialize($this->view->getData())) . '.php');
     }
 
     /**


### PR DESCRIPTION
Improved cache logic to use data as a cache key.
Without this improvement, It's possible that it sends wrong contents to someone unintentionally.
