### PR TITLE
Fixed issue causing new data for existing Base View to be ignored.

### DIFF
--- a/src/Process/MJML.php
+++ b/src/Process/MJML.php
@@ -34,7 +34,12 @@ class MJML
     public function __construct($view)
     {
         $this->view = $view;
-        $this->path = storage_path('framework/views/' . sha1($this->view->getPath()).sha1(serialize($this->view->getData())) . '.php');
+        // Hash combined data and path.  If either change, new pre-compiled file is generated.
+        $dataPathChecksum = hash('sha256', json_encode([
+            'path' => $this->view->getPath(),
+            'data' => $this->view->getData()
+        ]));
+        $this->path = storage_path("framework/views/{$dataPathChecksum}.mjml.php");
     }
 
     /**


### PR DESCRIPTION
Great plugin, thanks!

This pull request makes a minor change to the `MJML->path` property to prevent overriding the view generated by Laravel's `Compiler` with *post-evaluation* HTML content.  This causes subsequent requests using the same (cached) mjml/blade template to ignore updates to data.

Related: https://github.com/asahasrabuddhe/laravel-mjml/issues/13