### PR TITLE
use config('view.compiled') and follow VIEW_COMPILED_PATH if specified

### DIFF
--- a/src/Process/MJML.php
+++ b/src/Process/MJML.php
@@ -39,7 +39,7 @@ class MJML
             'path' => $this->view->getPath(),
             'data' => $this->view->getData(),
         ]));
-        $this->path = storage_path("framework/views/{$dataPathChecksum}.mjml.php");
+        $this->path = rtrim(config('view.compiled'), '/') . "/{$dataPathChecksum}.mjml.php";
     }
 
     /**
@@ -71,7 +71,7 @@ class MJML
         File::put($this->path, $html);
 
         $contentChecksum    = hash('sha256', $html);
-        $this->compiledPath = storage_path("framework/views/{$contentChecksum}.php");
+        $this->compiledPath = rtrim(config('view.compiled'), '/') . "/{$contentChecksum}.php";
 
         if (! File::exists($this->compiledPath)) {
             $this->process = Process::fromShellCommandline($this->buildCmdLineFromConfig());


### PR DESCRIPTION
Hello, I deployed a Laravel application into a AWS Lambda function like [this document](https://aws.amazon.com/jp/blogs/compute/the-serverless-lamp-stack-part-4-building-a-serverless-laravel-application/).

My project need to define `VIEW_COMPILED_PATH=/tmp/storage/framework/views` because only `/tmp` is writable directory.
Then, I faced a error and figured out this library define temporary file paths as `storage_path("framework/views/{$dataPathChecksum OR $contentChecksum}.mjml.php");` in [`/src/Process/MJML.php`](https://github.com/asahasrabuddhe/laravel-mjml/blob/master/src/Process/MJML.php)

I guess using `config('view.compiled')` is better because it works in both cases. This is the pull request.

`config('view.compiled')` is  defined as `env('VIEW_COMPILED_PATH', realpath(storage_path('framework/views')))` in [`config/view.php`](https://github.com/laravel/laravel/blob/8.x/config/view.php)