### PR TITLE
Fix html2text namespace

### DIFF
--- a/src/Process/MJML.php
+++ b/src/Process/MJML.php
@@ -2,7 +2,7 @@
 
 namespace Asahasrabuddhe\LaravelMJML\Process;
 
-use Html2Text\Html2Text;
+use Soundasleep\Html2Text;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\HtmlString;
 use Illuminate\View\View;


### PR DESCRIPTION
Fixes the namespace for the `Html2Text` class.

See https://github.com/soundasleep/html2text#installing & https://github.com/soundasleep/html2text/blob/master/CHANGELOG.md#100---2019-02-14