### PR TITLE
Bugfix

### DIFF
--- a/src/Process/MJML.php
+++ b/src/Process/MJML.php
@@ -2,7 +2,7 @@
 
 namespace Asahasrabuddhe\LaravelMJML\Process;
 
-use Html2Text\Html2Text;
+use Soundasleep\Html2Text;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\HtmlString;
 use Illuminate\View\View;


### PR DESCRIPTION
Soundasleep Vendor changed namespace in their newest version. 
Html2Text\Html2Text does not exist anymore and was renamed to Soundasleep\Html2Text