### PR TITLE
#141 set config.filePath to view location

### DIFF
--- a/src/Process/MJML.php
+++ b/src/Process/MJML.php
@@ -53,6 +53,7 @@ class MJML
             'node',
             config('mjml.auto_detect_path') ? $this->detectBinaryPath() : config('mjml.path_to_binary'),
             $this->path,
+            '--config.filePath=' . dirname($this->view->getPath()),
             '-o',
             $this->compiledPath,
         ]);


### PR DESCRIPTION
This enables usage of <mj-include> with paths relative to the view file.

See #141