### PR TITLE
fix public properties not available in the view

### DIFF
--- a/src/Mail/Mailable.php
+++ b/src/Mail/Mailable.php
@@ -25,7 +25,7 @@ class Mailable extends IlluminateMailable
     public function mjml($view, array $data = [])
     {
         $this->mjml     = $view;
-        $this->viewData = array_merge($this->viewData, $data);
+        $this->viewData = array_merge($this->buildViewData(), $data);
 
         return $this;
     }
@@ -59,7 +59,7 @@ class Mailable extends IlluminateMailable
      */
     protected function buildMjmlView()
     {
-        $view = View::make($this->mjml, $this->viewData);
+        $view = View::make($this->mjml, $this->buildViewData());
         $mjml = new MJML($view);
 
         return [


### PR DESCRIPTION
This PR will fix an issue with public properties not being available in the view.

For example, this will not work:
```php
class MyMail extends Mailable
{
    use Queueable, SerializesModels;

    public $myPublicProperty = 'Hello World';

    /**
     * Get the message content definition.
     *
     * @return \Illuminate\Mail\Mailables\Content
     */
    public function content()
    {
        return new Content(
            view: $this->mjml('mjml.thanks-for-your-application')->buildMjmlView()['html'],
        );
    }
}
```

What will work with current code is by set the `with` in the `Content` definition. 
```php
class MyMail extends Mailable
{
    use Queueable, SerializesModels;

    /**
     * Get the message content definition.
     *
     * @return \Illuminate\Mail\Mailables\Content
     */
    public function content()
    {
        return new Content(
            view: $this->mjml('mjml.thanks-for-your-application')->buildMjmlView()['html'],
            with: [
                'myPublicProperty' => 'Hello World',
            ]
        );
    }
}
```