### PR TITLE
Added MIT license

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "asahasrabuddhe/laravel-mjml",
     "description": "A package that enables using MJML with Laravel Mailables.",
+    "license" : "MIT",
     "authors": [
         {
             "name": "Ajitem Sahasrabuddhe",


### PR DESCRIPTION
As mentioned in [LICENSE](https://github.com/asahasrabuddhe/laravel-mjml/blob/master/LICENSE) document. This will get rid of the warning in packagist and tools like enlightn

---

<img width="1470" alt="image" src="https://user-images.githubusercontent.com/516807/210399152-6149245d-b325-486c-ab2a-5ef86d73de8d.png">


<img width="840" alt="image" src="https://user-images.githubusercontent.com/516807/210399177-3bef643b-950e-4971-bc25-3225d330aeff.png">
