### PR TITLE
hotfix: fix Mailable if mjml is not used

### DIFF
--- a/src/Mail/Mailable.php
+++ b/src/Mail/Mailable.php
@@ -20,7 +20,7 @@ class Mailable extends IlluminateMailable
      *
      * @var string
      */
-    protected $mjmlConcent = '';
+    protected $mjmlContent = '';
 
     /**
      * Set the MJML template for the message.

--- a/src/Mail/Mailable.php
+++ b/src/Mail/Mailable.php
@@ -16,6 +16,13 @@ class Mailable extends IlluminateMailable
     protected $mjml;
 
     /**
+     * The MJML content for the message (if applicable).
+     *
+     * @var string
+     */
+    protected $mjmlConcent = '';
+
+    /**
      * Set the MJML template for the message.
      *
      * @param  string  $view
@@ -31,13 +38,27 @@ class Mailable extends IlluminateMailable
     }
 
     /**
+     * Set the MJML content for the message.
+     *
+     * @param  string  $view
+     * @param  array  $data
+     * @return $this
+     */
+    public function mjmlContent($mjmlContent)
+    {
+        $this->mjmlContent = $mjmlContent;
+
+        return $this;
+    }
+
+    /**
      * Build the view for the message.
      *
      * @return array|string
      */
     protected function buildView()
     {
-        if (isset($this->mjml)) {
+        if (isset($this->mjml) || isset($this->mjmlContent)) {
             return $this->buildMjmlView();
         }
         if (isset($this->markdown)) {
@@ -59,8 +80,10 @@ class Mailable extends IlluminateMailable
      */
     protected function buildMjmlView()
     {
-        $view = View::make($this->mjml, $this->buildViewData());
-        $mjml = new MJML($view);
+        if (isset($this->mjml)) {
+            $this->mjmlContent = View::make($this->mjml, $this->buildViewData());
+        }
+        $mjml = new MJML($this->mjmlContent);
 
         return [
             'html' => $mjml->renderHTML(),

--- a/src/Mail/Mailable.php
+++ b/src/Mail/Mailable.php
@@ -20,7 +20,7 @@ class Mailable extends IlluminateMailable
      *
      * @var string
      */
-    protected $mjmlContent = '';
+    protected $mjmlContent = null;
 
     /**
      * Set the MJML template for the message.

--- a/src/Mail/Mailable.php
+++ b/src/Mail/Mailable.php
@@ -40,8 +40,7 @@ class Mailable extends IlluminateMailable
     /**
      * Set the MJML content for the message.
      *
-     * @param  string  $view
-     * @param  array  $data
+     * @param  string  $mjmlContent
      * @return $this
      */
     public function mjmlContent($mjmlContent)

--- a/src/Process/MJML.php
+++ b/src/Process/MJML.php
@@ -43,7 +43,7 @@ class MJML
             // Hash combined data and path.  If either change, new pre-compiled file is generated.
             $dataPathChecksum = hash('sha256', $mjmlViewOrMjml);
         } else {
-            $this->view = $view;
+            $this->view = $mjmlViewOrMjml;
             // Hash combined data and path.  If either change, new pre-compiled file is generated.
             $dataPathChecksum = hash('sha256', json_encode([
                 'path' => $this->view->getPath(),


### PR DESCRIPTION
I introduced an error if `mjml()` or `mjmlContent()` is not used and the base class takes over. In fact, `isset($this->mjmlContent)` is always true.