### PR TITLE
Setting the path for NODE in config

### DIFF
--- a/src/Process/MJML.php
+++ b/src/Process/MJML.php
@@ -62,7 +62,7 @@ class MJML
     public function buildCmdLineFromConfig()
     {
         return implode(' ', [
-            'node',
+            config('mjml.node_path'),
             config('mjml.auto_detect_path') ? $this->detectBinaryPath() : config('mjml.path_to_binary'),
             $this->path,
             $this->view ? '--config.filePath=' . dirname($this->view->getPath()) : '',

--- a/src/config/mjml.php
+++ b/src/config/mjml.php
@@ -14,4 +14,8 @@ return [
      * The path to the MJML binary
      */
      'path_to_binary' => env('MJML_PATH_TO_BINARY', ''),
+    /*
+     * The path to the NODE binary
+     */
+     'node_path' => env('MJML_NODE_PATH', 'node'),
 ];


### PR DESCRIPTION
Solving the problem with an error starting node from Windows.
Allows you to specify the full path to the NODE of the binary.