### PR TITLE
Allow symfony process v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php-coveralls/php-coveralls": "^2.5.2"
     },
     "require": {
-        "symfony/process": "^4.0.0|^5.0.0|^6.0.0",
+        "symfony/process": "^4.0.0|^5.0.0|^6.0.0|^7.0.0",
         "soundasleep/html2text": "~2.1.0"
     }
 }


### PR DESCRIPTION
Can we allow symfony process v7 which is a requirement for laravel 11? Seems to work fine otherwise